### PR TITLE
Fix Renovate CI: environment vars and Discord notifications

### DIFF
--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -8,6 +8,7 @@ when:
   - event: tag
   - event: cron
     cron: renovate
+  - event: manual
 
 variables:
   - &ci_image jlipworth/stock-pitch-ci:latest

--- a/.woodpecker.yml
+++ b/.woodpecker.yml
@@ -47,9 +47,30 @@ steps:
         cron: renovate
     environment:
       RENOVATE_TOKEN:
-        from_secret: github_token
+        from_secret: github_pat
+      RENOVATE_PLATFORM: github
+      RENOVATE_REPOSITORIES: jlipworth/stockpitch-study
+      RENOVATE_GIT_AUTHOR: "Renovate Bot <renovate@noreply.github.com>"
+      LOG_LEVEL: info
     commands:
-      - renovate --platform github --repositories jlipworth/stockpitch-study
+      - renovate
+
+  - name: notify-renovate
+    image: appleboy/drone-discord
+    depends_on:
+      - renovate
+    when:
+      - event: cron
+        cron: renovate
+    settings:
+      webhook_id:
+        from_secret: discord_id
+      webhook_token:
+        from_secret: discord_token
+      message: >
+        🔄 **Renovate** completed for {{repo.name}}
+        Check for new dependency update PRs
+        {{build.link}}
 
   - name: notify-success
     image: appleboy/drone-discord

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended"
   ],
   "onboarding": false,
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "14 days",
   "pep621": {
     "enabled": true
   },
@@ -35,6 +35,5 @@
   "prHourlyLimit": 2,
   "prConcurrentLimit": 5,
   "labels": ["dependencies"],
-  "commitMessagePrefix": "chore(deps):",
-  "schedule": ["after 9am on Monday"]
+  "commitMessagePrefix": "chore(deps):"
 }


### PR DESCRIPTION
## Summary
- Switch Renovate to use environment variables instead of CLI args for cleaner config
- Use `github_pat` secret instead of `github_token`
- Add Discord notification step for Renovate cron runs
- Increase `minimumReleaseAge` from 3 to 14 days for more stable dependencies
- Remove schedule constraint (let Renovate run on cron trigger only)